### PR TITLE
Different Aggregation periods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # directories
 
 build/
+data/
 .cache/
 dist/
 docs/_gh-pages


### PR DESCRIPTION
Using `watson aggregate` is very handy when it comes to getting an overview of tracked times over a given period. Unfortunately, this can still be a bit overwhelming when aggregating larger periods of time.

This patch allows aggregation not only on a daily, but also on a weekly or monthly basis. This makes it easier to review whats happening.

Original PR: https://github.com/TailorDev/Watson/pull/496/