### PR TITLE
devshell: add python LSP

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,12 @@
             devshell.packages = with pkgs; [
               gnumake
               virtualenv
+              (pkgs.python3.withPackages (p: [
+                # select Python packages here
+                p.python-lsp-ruff
+                p.python-lsp-server
+                p.python-lsp-server.optional-dependencies
+              ]))
             ];
           };
         });


### PR DESCRIPTION
Adds required dependencies for using `pylsp` with a nix devshell in neovim.